### PR TITLE
Generate SRPM repos

### DIFF
--- a/conf/config.inc
+++ b/conf/config.inc
@@ -30,6 +30,7 @@ DNF_OPTIONS_BINARY_ONLY="-c ${REPO_DIR}/rawhide.repo --disablerepo=* --enablerep
 BR_BINARY_PKGNAMES_FILENAME="buildroot-binary-package-names.txt"
 BR_SOURCE_PKGNAMES_FILENAME="buildroot-source-package-names.txt"
 BR_ARCHFUL_SOURCE_PKGNAMES_FILENAME="buildroot-archful-srpm-names.txt"
+BR_SOURCE_PKGMAP_FILENAME="buildroot-package-to-srpm-map.txt"
 BR_TIMESTAMP_FILENAME="buildroot-date-check.txt"
 EMAIL_LIST="tdawson@redhat.com"
 DT_ACTION_LIST="email"

--- a/create-srpm-buildroot-repos
+++ b/create-srpm-buildroot-repos
@@ -1,0 +1,177 @@
+#!/bin/bash
+# Usage: create-srpm-buildroot-repos
+
+WORK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source $WORK_DIR/conf/config.inc
+
+errexit() {
+    echo "$@" >&2
+    exit 5
+}
+
+#####
+# Variables
+#####
+# DIRS
+# FILES/VARIABLES
+# BINARY VARIABLES
+# LIST VARIABLES
+# ASSOCIATIVE ARRAY VARIABLES
+declare -A ARCHFUL_SOURCE_LIST
+declare -A SRPM_MAPPING
+declare -a SOURCE_LIST
+
+
+# read_source_package_lists outfile
+# data_dir: directory from which to read package lists
+# srpm_dir: directory in which source rpms can be found
+#
+# Read in the list of archful source packages into global associative
+# array ARCHFUL_SOURCE_LIST, and the mapping of package names to SRPM
+# file names into global associative array SRPM_MAPPING.
+read_source_package_lists() {
+  local data_dir="$1"
+  local srpm_dir="$2"
+
+  local archful_pkglist_file="${data_dir}/${BR_ARCHFUL_SOURCE_PKGNAMES_FILENAME}"
+  local pkg_to_srpm_map_file="${data_dir}/${BR_SOURCE_PKGMAP_FILENAME}"
+  local pkgname srpm
+
+  # read in the list of archful source packages
+  while read pkgname
+  do
+    ARCHFUL_SOURCE_LIST[${pkgname}]=1
+  done < "${archful_pkglist_file}"
+
+  # read in the mapping of package names to SRPM base file names
+  while IFS="=" read pkgname srpm
+  do
+    SRPM_MAPPING[${pkgname}]="${srpm_dir}/${srpm}"
+  done < "${pkg_to_srpm_map_file}"
+
+  echo "${#ARCHFUL_SOURCE_LIST[@]} archful buildroot source packages."
+  echo "${#SRPM_MAPPING[@]} buildroot source packages for all architectures combined."
+}
+
+
+# read_arch_source_package_list arch data_dir
+# arch: the architecture
+# data_dir: directory from which to read package lists
+#
+# Read the arch-specific buildroot source package list into
+# global array SOURCE_LIST.
+read_arch_source_package_list() {
+  local arch="$1"
+  local data_dir="$2"
+
+  local src_pkgs_file="${data_dir}/${BR_SOURCE_PKGNAMES_FILENAME}"
+
+  echo "Reading source package list for arch ${arch}..."
+
+  if [ ! -r "${src_pkgs_file}" ] ; then
+    errexit "Missing buildroot source package list file for arch ${arch}: ${src_pkgs_file}"
+  fi
+
+  mapfile -t SOURCE_LIST < "${src_pkgs_file}"
+
+  if [ ${#SOURCE_LIST[@]} -eq 0 ] ; then
+    errexit "No buildroot source packages listed in ${src_pkgs_file}."
+  fi
+
+  echo "${#SOURCE_LIST[@]} buildroot source packages for arch ${arch}."
+}
+
+# populate_arch_source_rpm_repo arch arch_repo_dir pkg1 pkg2 ...
+# arch: the architecture
+# arch_repo_dir: arch-specific directory for repos
+# pkg1 ...: list of base source package names to add to repo
+populate_arch_source_rpm_repo() {
+  local arch="$1"
+  local arch_repo_dir="$2"
+  local -a pkg_list=("${@:3}")
+
+  local this_package srpm srpm_in_repo
+
+  echo "Building source package repo for arch $arch with ${#pkg_list[@]} packages"
+
+  mkdir -p "${arch_repo_dir}/sources"
+  for this_package in "${pkg_list[@]}"
+  do
+    srpm="${SRPM_MAPPING[${this_package}]}"
+    srpm_in_repo="${arch_repo_dir}/sources/${srpm##*/}"
+    if [ -v ARCHFUL_SOURCE_LIST["${this_package}"] ]; then
+      # archful SRPMs should already exist since they were previously rebuilt
+      if [ ! -r "${srpm_in_repo}" ]; then
+        echo "WARNING: Archful SRPM missing from target repo location!: ${srpm_in_repo}"
+      fi
+      continue
+    fi
+    # make a hard link from source directory if not present in repo
+    if [ ! -r "${srpm_in_repo}" ]; then
+      ln "${srpm}" "${srpm_in_repo}"
+    fi
+  done
+}
+
+# recreate_archful_source_packages repos_dir srpm_dir pkg1 pkg2 ...
+# repos_dir: top level directory for repos
+# srpm_dir: directory in which source rpms can be found
+# pkg1 ...: list of base source package names to recreate and add to repo
+recreate_archful_source_packages() {
+  local repos_dir="$1"
+  local srpm_dir="$2"
+  local -a pkg_list=("${@:3}")
+
+  local this_package srpm
+  local scratch_srpm_file=$(mktemp)
+
+  echo "Recreating source packages for ${#pkg_list[@]} archful packages"
+
+  # write out a list to all of the source packages to be rebuilt
+  for this_package in "${pkg_list[@]}"
+  do
+    echo "${SRPM_MAPPING[${this_package}]##*/}"
+  done > "${scratch_srpm_file}"
+
+  # Usage: mock-recreate-srpms output-dir srpm-dir srpm-list-file [ version ]
+  ${WORK_DIR}/mock-recreate-srpms "${repos_dir}" "${srpm_dir}" "${scratch_srpm_file}"
+
+  rm -f "${scratch_srpm_file}"
+}
+
+# update_arch_repo_metadata arch arch_repo_dir
+# arch: the architecture
+# arch_repo_dir: arch-specific directory for repos
+update_arch_repo_metadata() {
+  local arch="$1"
+  local arch_data_dir="$2"
+
+  echo "Updating repo metadata for arch ${arch}"
+  createrepo_c --update "${arch_repo_dir}"
+}
+
+echo "Creating architecture-specific source package buildroot repos  ..."
+
+data_dir="${DATA_DIR_BASE}/source/${NEW_DIR}"
+srpm_dir="${data_dir}/srpms"
+repos_dir="${DATA_DIR_BASE}/repos/${NEW_DIR}"
+
+read_source_package_lists "${data_dir}" "${srpm_dir}"
+
+recreate_archful_source_packages "${repos_dir}" "${srpm_dir}" ${!ARCHFUL_SOURCE_LIST[@]}
+
+for this_arch in ${ARCH_LIST[@]}
+do
+  echo "Working on arch ${this_arch}  ..."
+
+  arch_data_dir="${DATA_DIR_BASE}/${this_arch}/${NEW_DIR}"
+  arch_repo_dir="${DATA_DIR_BASE}/repos/${NEW_DIR}/${this_arch}"
+
+  read_arch_source_package_list ${this_arch} "${arch_data_dir}"
+
+  populate_arch_source_rpm_repo ${this_arch} "${arch_repo_dir}" ${SOURCE_LIST[@]}
+
+  update_arch_repo_metadata ${this_arch} "${arch_repo_dir}"
+done
+
+exit 0

--- a/identify-archful-srpms
+++ b/identify-archful-srpms
@@ -20,13 +20,6 @@ declare -A MERGED_SOURCE_LIST
 declare -A ARCHFUL_SOURCE_LIST
 declare -A SRPM_DOWNLOADED_LIST
 
-#####
-# General setup
-#####
-
-dnf --quiet clean all
-
-echo "Identifying source packages that may differ based on architecture  ..."
 
 # merge_source_package_lists
 #
@@ -215,18 +208,34 @@ find_archful_source_packages() {
   echo "${#ARCHFUL_SOURCE_LIST[@]} archful buildroot source packages identified."
 }
 
-# write_archful_source_package_list outfile
-# outfile: file to which to write sorted list
+# write_source_package_lists data_dir
+# data_dir: directory to which to write package lists
 #
-# Write out the list of archful source packages
-write_archful_source_package_list() {
-  local outfile="$1"
-  printf "%s\n" "${!ARCHFUL_SOURCE_LIST[@]}" | sort -o "$outfile"
+# Write out the list of archful source packages and mapping of package
+# names to SRPM base file names.
+write_source_package_lists() {
+  local data_dir="$1"
+  local archful_pkglist_file="${data_dir}/${BR_ARCHFUL_SOURCE_PKGNAMES_FILENAME}"
+  local pkg_to_srpm_map_file="${data_dir}/${BR_SOURCE_PKGMAP_FILENAME}"
+
+  # write out the list of archful source packages
+  printf "%s\n" "${!ARCHFUL_SOURCE_LIST[@]}" | sort -o "${archful_pkglist_file}"
+
+  # write out the mapping of package names to SRPM base file names
+  for pkgname in ${!SRPM_DOWNLOADED_LIST[@]}
+  do
+    echo "${pkgname}=${SRPM_DOWNLOADED_LIST[${pkgname}]##*/}"
+  done \
+  | sort -o "${pkg_to_srpm_map_file}"
 }
+
+
+dnf --quiet clean all
+
+echo "Identifying source packages that may differ based on architecture  ..."
 
 data_dir="${DATA_DIR_BASE}/source/${NEW_DIR}"
 srpm_dir="${data_dir}/srpms"
-archful_pkglist_file="${data_dir}/${BR_ARCHFUL_SOURCE_PKGNAMES_FILENAME}"
 
 merge_source_package_lists
 
@@ -238,6 +247,6 @@ check_source_rpms "${srpm_dir}"
 
 find_archful_source_packages "${srpm_dir}"
 
-write_archful_source_package_list "${archful_pkglist_file}"
+write_source_package_lists "${data_dir}"
 
 exit 0

--- a/identify-archful-srpms
+++ b/identify-archful-srpms
@@ -77,12 +77,13 @@ merge_source_package_lists() {
 # pkg1 ...: list of base package names for which to download source rpms
 download_source_rpms() {
   local srpm_dir="$1"
-  shift
+  local -a pkg_list=("${@:2}")
+
   # pick first arch as forced arch for source download, since they're all the same
   local src_dl_arch=${ARCH_LIST[0]}
 
   echo "Downloading SRPMs."
-  dnf --quiet --forcearch=${src_dl_arch} ${DNF_OPTIONS_SOURCE_ONLY} download --downloaddir "${srpm_dir}" --source "$@"
+  dnf --quiet --forcearch=${src_dl_arch} ${DNF_OPTIONS_SOURCE_ONLY} download --downloaddir "${srpm_dir}" --source "${pkg_list[@]}"
 }
 
 # order_srpm_files srpm1 srpm2

--- a/mock-recreate-srpms
+++ b/mock-recreate-srpms
@@ -1,0 +1,136 @@
+#!/usr/bin/bash
+# Usage: $0 output-dir srpm-dir srpm-list-file [ version ]
+#
+# Based upon mock_wrapper.sh, recreate_srpm.sh, and populate_srpm_repo.sh
+# from https://github.com/fedora-modularity/baseruntime-package-lists
+
+errexit() {
+    echo "$@" >&2
+    exit 5
+}
+
+if [ $# -lt 3 -o $# -gt 4 ]; then
+    errexit "Usage: $0 output-dir srpm-dir srpm-list-file [ version ]"
+fi
+
+output_dir="$1"
+srpm_dir="$2"
+srpm_list_file="$3"
+release_ver="${4:-rawhide}"
+
+WORK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source $WORK_DIR/conf/config.inc
+
+set -e
+
+nproc=$(/usr/bin/getconf _NPROCESSORS_ONLN)
+
+vernum=${release_ver}
+if [ "${release_ver}" == "rawhide" ]; then
+    vernum=33
+fi
+
+# load list of srpms from input file into array variable
+mapfile -t srpm_list < "${srpm_list_file}"
+# make sure we have just the basenames of the SRPMs
+srpm_basename_list=(${srpm_list[@]##*/})
+
+mock_cfg=${WORK_DIR}/fedora-${release_ver}-srpm.cfg
+
+cat > ${mock_cfg} <<EOF
+config_opts['root'] = 'fedora-$release_ver-srpm'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64')
+config_opts['chroot_setup_cmd'] = 'install bash fedora-release fedpkg gnupg2 git-core redhat-rpm-config rpm-build shadow-utils gawk koji glibc-minimal-langpack rpmdevtools'
+config_opts['dist'] = 'fc$vernum'  # only useful for --resultdir variable subst
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['releasever'] = '$vernum'
+config_opts['package_manager'] = 'dnf'
+config_opts['use_bootstrap'] = False
+config_opts['rpmbuild_networking'] = True
+
+# Configure bind mounts for the the srpms and output directories
+config_opts['plugin_conf']['bind_mount_enable'] = True
+config_opts['plugin_conf']['bind_mount_opts']['dirs'].append(('$srpm_dir', '/opt/srpm/srpms/' ))
+config_opts['plugin_conf']['bind_mount_opts']['dirs'].append(('$output_dir', '/opt/srpm/output/' ))
+
+config_opts['yum.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+install_weak_deps=0
+metadata_expire=0
+mdpolicy=group:primary
+best=1
+
+# repos
+$(cat ${REPO_DIR}/${release_ver}.repo)
+"""
+EOF
+
+# read script into variable; use ! to bypass "set -e" exit
+! read -r -d '' mock_recreate_srpm_script <<'EOF'
+#!/usr/bin/bash
+
+if [ $# -ne 1 ]; then
+    echo "Missing source-rpm argument"
+    echo "Usage: recreate_srpm.sh source-rpm"
+    exit 1
+fi
+
+srpm="$1"
+
+pkgname=$(rpm -q --nosignature --qf "%{name}" -p ${srpm})
+
+echo "Rebuilding ${pkgname} SRPMs from ${srpm}"
+
+output_dir=$(pwd)
+scratch_dir=$(mktemp -d)
+
+pushd ${scratch_dir}
+
+rpm2cpio ${srpm} | cpio -idm
+
+for arch in __ARCH_LIST__; do
+    mkdir -p ${output_dir}/${arch}/sources
+    rpmbuild -bs \
+             --build-in-place \
+             --target=${arch} \
+             --define "_sourcedir ${scratch_dir}" \
+             --define "_srcrpmdir ${output_dir}/${arch}/sources" \
+             ${pkgname}.spec
+done
+
+popd # ${scratch_dir}
+
+rm -rf ${scratch_dir}
+EOF
+
+# fill in architecture list placeholder with actual list
+mock_recreate_srpm_script="${mock_recreate_srpm_script//__ARCH_LIST__/${ARCH_LIST[@]}}"
+
+# make sure target output directory exists
+mkdir -p "${output_dir}"
+
+mock -r ${mock_cfg} --init
+# Note: the mock configuration bind mounts the srpms and output directories
+mock -r ${mock_cfg} --chroot "mkdir -p /opt/srpm/srpms /opt/srpm/output"
+mock -r ${mock_cfg} --copyin /dev/stdin /opt/srpm/recreate_srpm.sh \
+                             <<<"${mock_recreate_srpm_script}"
+mock -r ${mock_cfg} --copyin /dev/stdin /opt/srpm/srpm-list.txt \
+                             <<<$(printf "/opt/srpm/srpms/%s\n" ${srpm_basename_list[@]})
+mock -r ${mock_cfg} --chroot "
+    cd /opt/srpm/output
+    chmod a+rx /opt/srpm/recreate_srpm.sh
+    cat /opt/srpm/srpm-list.txt | xargs --max-procs=${nproc} -I SRPM /opt/srpm/recreate_srpm.sh SRPM
+"
+# reset ownership of output directory
+mock -r ${mock_cfg} --chroot "chown -R mockbuild:mock /opt/srpm/output"


### PR DESCRIPTION
Adding `create-srpm-buildroot-repos` and a helper script it calls, `mock-recreate-srpms`.

The basic functionality is there, although there is still at least one glitch to work out. (Such as what to do about SRPM rebuilds for archful packages that are FTBFS in Rawhide.)

And, of course, there are ample opportunities for optimization--particularly when it comes to skipping unchanged packages when re-running the script.