### PR TITLE
Generalized command line argument parsing

### DIFF
--- a/conf/config.inc
+++ b/conf/config.inc
@@ -38,7 +38,8 @@ DT_ACTION_LIST="email"
 # Show help
 ###############
 usage() {
-  echo "Usage `basename $0` <options>" >&2
+  echo >&2
+  echo "Usage `basename $0` <options> [ [--] ...]" >&2
   echo >&2
   echo "Options:" >&2
   echo "  -r | --repo [reponame]" >&2
@@ -55,18 +56,27 @@ usage() {
 ###############
 while [[ "$#" -ge 1 ]]
 do
-  key="$1"
-  case $key in
+  case "$1" in
     -r | --repo )
         REPONAME="${2}"
-        shift
-    ;;
+        shift 2
+        ;;
     -p | --pkglist )
         PACKAGELIST_DIR="${2}"
+        shift 2
+        ;;
+    -- )
         shift
-    ;;
+        break
+        ;;
+    -* )
+        echo "Unknown option: $1" >&2
+        usage
+        ;;
+    * )
+        break
+        ;;
   esac
-  shift # past argument or value
 done
 
 #####

--- a/create-srpm-repos
+++ b/create-srpm-repos
@@ -227,8 +227,8 @@ recreate_archful_source_packages() {
     echo "${srpm}"
   done > "${scratch_srpm_file}"
 
-  # Usage: mock-recreate-srpms output-dir srpm-dir srpm-list-file [ version ]
-  ${WORK_DIR}/mock-recreate-srpms "${repos_dir}" "${srpm_dir}" "${scratch_srpm_file}"
+  # Usage: mock-recreate-srpms [ --repo reponame ] output-dir srpm-dir srpm-list-file
+  ${WORK_DIR}/mock-recreate-srpms --repo "${REPONAME}" "${repos_dir}" "${srpm_dir}" "${scratch_srpm_file}"
 
   rm -f "${scratch_srpm_file}"
 }

--- a/mock-recreate-srpms
+++ b/mock-recreate-srpms
@@ -1,5 +1,5 @@
 #!/usr/bin/bash
-# Usage: $0 output-dir srpm-dir srpm-list-file [ version ]
+# Usage: $0 [ --repo reponame ] output-dir srpm-dir srpm-list-file
 #
 # Based upon mock_wrapper.sh, recreate_srpm.sh, and populate_srpm_repo.sh
 # from https://github.com/fedora-modularity/baseruntime-package-lists
@@ -9,17 +9,17 @@ errexit() {
     exit 5
 }
 
-if [ $# -lt 3 -o $# -gt 4 ]; then
-    errexit "Usage: $0 output-dir srpm-dir srpm-list-file [ version ]"
+WORK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source $WORK_DIR/conf/config.inc
+
+if [ $# -ne 3 ]; then
+    errexit "Usage: $0 [ --repo reponame ] output-dir srpm-dir srpm-list-file"
 fi
 
 output_dir="$1"
 srpm_dir="$2"
 srpm_list_file="$3"
-release_ver="${4:-rawhide}"
-
-WORK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source $WORK_DIR/conf/config.inc
+release_ver="${REPONAME}"
 
 set -e
 
@@ -72,7 +72,7 @@ mdpolicy=group:primary
 best=1
 
 # repos
-$(cat ${REPO_DIR}/${release_ver}.repo)
+$(cat ${REPO_DIR}/${REPONAME}.repo)
 """
 EOF
 


### PR DESCRIPTION
Updated `conf/config.inc` to do more generalized command line argument parsing, then updated `create-srpm-repos` and `mock-recreate-srpms` to make use of that. It would be possible to implement additional command line option parsing in these scripts--but this is a start.

